### PR TITLE
fix(permissions): fix POST /my_permissions endpoint

### DIFF
--- a/middlewares/my-permissions.js
+++ b/middlewares/my-permissions.js
@@ -37,6 +37,7 @@ exports.getMyCirclesWithPermission = async (req, res) => {
 
     const result = await Circle.findAndCountAll({
         where: {
+            '$circle_memberships.user_id$': req.user.id,
             '$circle_memberships.circle_id$': { [Sequelize.Op.in]: circleIds },
             ...helpers.filterBy(req.query.query, constants.FIELDS_TO_QUERY.CIRCLE)
         },


### PR DESCRIPTION
okay, so let's start doing things through PR properly :D

so there's POST /my_permissions endpoint, which accepts the body as JSON with action and object, and returns a list of circles where I have this permission (local one). and it's used in both events and statutory services to get the list of circles (and therefore bodies), where I have this permission.
how it works: it takes the local:action:object permission, then queries all CirclePermissions for this permission, then recursively gets the list of all the direct and indirect circles for this permission (like, if the General Board circle has this permission, then Board AEGEE-Moskva, inherited from it, also has it).
then it queries for all circles, where I am a member (I've missed this part) from this circles list and returns it to the client.

this is on prod now, now I'm committing it properly.
also wrote a test that fails without my edit and passed with it.