### PR TITLE
fix(logging): hide more sensitive stuff

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -40,7 +40,7 @@ function unflattenObject(data) {
 const filterFields = (body) => {
     const flatten = flattenObject(body);
     for (const field in flatten) {
-        if (configFile.filter_fields.some((filterField) => field === filterField)) {
+        if (configFile.filter_fields.some((filterField) => field.includes(filterField))) {
             flatten[field] = '*'.repeat(flatten[field].length);
         }
     }


### PR DESCRIPTION
we do not log field if it's exactly the one of the fields in the stop list, but we don't if it includes it. for example, `password` is hidden, but `password_copy` isn't

this makes it a little bit more broad by filtering not only fields that are named exactly the same as in config, but also if it contains one of the fields in the config.